### PR TITLE
fix: Change nglcobdai-utils dependency from 'rev' to 'tag'

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1189,4 +1189,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "0847053a44ff8574bb39f96bd5c1049d8d85fe55cfa93be52fc9c64e75405233"
+content-hash = "2222f92cea668b327d5c43fbad417a817beb6658295228726fe98b2fbd6039a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ opencv-python = "^4.8.1.78"
 pyyaml = "^6.0.1"
 tqdm = "^4.66.1"
 matplotlib = "^3.8.1"
-nglcobdai-utils = {git = "https://github.com/nglcobdai/nglcobdai-utils.git", rev = "v0.2.0" }
+nglcobdai-utils = {git = "https://github.com/nglcobdai/nglcobdai-utils.git", tag = "v0.2.0"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## 🔨 変更内容

This pull request includes a minor update to the dependency specification in the `pyproject.toml` file. The change replaces the `rev` key with the `tag` key for the `nglcobdai-utils` dependency to improve clarity and alignment with standard practices.

## 💡 特筆事項

## 📸 スクリーンショット

## ✅ 解決するイシュー

## 🤝 関連するイシュー
