### PR TITLE
fix: Update nglcobdai-utils dependency to version v0.2.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -483,7 +483,7 @@ files = [
 
 [[package]]
 name = "nglcobdai-utils"
-version = "v0.2.0"
+version = "v0.2.1"
 description = ""
 optional = false
 python-versions = "^3.10"
@@ -500,8 +500,8 @@ slack-sdk = "^3.32.0"
 [package.source]
 type = "git"
 url = "https://github.com/nglcobdai/nglcobdai-utils.git"
-reference = "v0.2.0"
-resolved_reference = "84938aff29bdc0cbe852831390f62080c63c79ef"
+reference = "v0.2.1"
+resolved_reference = "00ce84333ee893fd6a2d8abd670ff662af8664cf"
 
 [[package]]
 name = "numpy"
@@ -1271,4 +1271,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "e28b2d18f52b784a0df5a6bb1dd6a54607bef24d4ec6c3d6ae59b1a3ca247411"
+content-hash = "4502d1b67ca79946792907eec588429d49d9fcf57a7cacea0c71f7075b35c582"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blob-effect"
-version = "v2.0.5"
+version = "v2.0.6"
 description = ""
 authors = ["Kodai YAMASHITA <nglcobdai@gmail.com>"]
 readme = "README.md"
@@ -16,7 +16,7 @@ opencv-python-headless = "4.11.0.86"
 pyyaml = "^6.0.1"
 tqdm = "^4.66.1"
 matplotlib = "^3.8.1"
-nglcobdai-utils = {git = "https://github.com/nglcobdai/nglcobdai-utils.git", tag = "v0.2.0"}
+nglcobdai-utils = {git = "https://github.com/nglcobdai/nglcobdai-utils.git", tag = "v0.2.1"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## 🔨 変更内容

This pull request updates the project version and a dependency version in the `pyproject.toml` file.

* Updated project version from `v2.0.5` to `v2.0.6` to reflect the latest release.
* Updated the `nglcobdai-utils` dependency to use tag `v0.2.1` instead of `v0.2.0`.

## 💡 特筆事項

## 📸 スクリーンショット

## ✅ 解決するイシュー

## 🤝 関連するイシュー
