### PR TITLE
chore: bump version to v2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blob-effect"
-version = "v2.0.6"
+version = "v2.1.0"
 description = ""
 authors = ["Kodai YAMASHITA <nglcobdai@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version from `v2.0.6` to `v2.1.0` for the v2.1.0 release.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)